### PR TITLE
fix: add auto versioning

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Increment Version
+        run: ./version.sh
       - name: Build
         run: make release
       - name: Upload artifacts

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/checkout@v1
       - name: Increment Version
         run: ./version.sh
+      - uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
       - name: Build
         run: make release
       - name: Upload artifacts

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+CURVER=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" AppGrid/AppGrid-Info.plist)
+
+MAJOR=$(echo "$CURVER" | awk -F "." '{print $1}')
+MINOR=$(echo "$CURVER" | awk -F "." '{print $2}')
+PATCH=$(echo "$CURVER" | awk -F "." '{print $3}')
+
+MSG=$(git log -1 --format=%s)
+
+# Follow conventaional commits?
+# https://www.conventionalcommits.org/en/v1.0.0/
+case $MSG in
+  "fix"*)
+          PATCH=$($PATCH + 1)
+    ;;
+  "feat"*)
+          MINOR=$($MINOR + 1)
+    ;;
+  "BREAKING CHANGE"*)
+          MAJOR=$($MAJOR + 1)
+    ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $NEW_VERSION" AppGrid/AppGrid-Info.plist
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_VERSION" AppGrid/AppGrid-Info.plist

--- a/version.sh
+++ b/version.sh
@@ -16,9 +16,12 @@ case $MSG in
     ;;
   "feat"*)
           MINOR=$($MINOR + 1)
+          PATCH="0"
     ;;
   "BREAKING CHANGE"*)
           MAJOR=$($MAJOR + 1)
+          MINOR="0"
+          PATCH="0"
     ;;
 esac
 


### PR DESCRIPTION
@opsroller what do you think? 

If PR titles get squashed into the commit message when it merges into master, we'll get auto versioning.

So if you name your pr starting with fix/feat/BREAKING CHANGE it'll auto increment the version for the release. I couldn't find anything that just did it for us, so I hacked together a script and used the conventional commits pattern. 

 